### PR TITLE
Compute_new take into account old Header values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,8 +329,8 @@ impl GptDisk {
     ) -> io::Result<&Self> {
         // TODO(lucab): validate partitions.
         let bak = header::find_backup_lba(&mut self.file, self.config.lb_size)?;
-        let h1 = header::Header::compute_new(true, &pp, self.guid, bak)?;
-        let h2 = header::Header::compute_new(false, &pp, self.guid, bak)?;
+        let h1 = header::Header::compute_new(true, &pp, self.guid, bak, &self.primary_header)?;
+        let h2 = header::Header::compute_new(false, &pp, self.guid, bak, &self.backup_header)?;
         self.primary_header = Some(h1);
         self.backup_header = Some(h2);
         self.partitions = pp;
@@ -366,10 +366,20 @@ impl GptDisk {
                 self.config.lb_size,
             )?;
         }
-        let new_backup_header =
-            header::Header::compute_new(false, &self.partitions, self.guid, bak)?;
-        let new_primary_header =
-            header::Header::compute_new(true, &self.partitions, self.guid, bak)?;
+        let new_backup_header = header::Header::compute_new(
+            false,
+            &self.partitions,
+            self.guid,
+            bak,
+            &self.primary_header,
+        )?;
+        let new_primary_header = header::Header::compute_new(
+            true,
+            &self.partitions,
+            self.guid,
+            bak,
+            &self.backup_header,
+        )?;
         debug!("Writing backup header");
         new_backup_header.write_backup(&mut self.file, self.config.lb_size)?;
         debug!("Writing primary header");


### PR DESCRIPTION
When writing to disk header, give old header (if exists) to compute new to keep the first_usable and last_usable attributes so as to not break the GPT (partprobe will complaing about not using all space available.  Especially since the first_usable is not always sector 34.  In fact, it is usually 2048 in order to align partition boundaries. Otherwise, if the original headers are not given, use the default values